### PR TITLE
Add title tag to portable html page

### DIFF
--- a/passhashplus.html
+++ b/passhashplus.html
@@ -36,6 +36,7 @@
 -->
 <html>
 <head>
+<title>Password Hasher Plus - portable page</title>
 <style>
 * { font-family: Arial; font-size: 12px; }
 </style>


### PR DESCRIPTION
Adds a title to the portable page to give the tab in chrome a nicer title than "chrome-extension://...passhashplus.html".
