### PR TITLE
Remove unsafe eval during inlining of scripts

### DIFF
--- a/passhashplus.js
+++ b/passhashplus.js
@@ -120,11 +120,11 @@ $( document ).ready(function () {
     $('#is-file-portable').text("true");
     var gettings = $("script").map(function(_i, script){ //1
       if (script.type == "text/javascript"){
-        return $.get($(script).attr('src'), function (data) { //1.a
+        return $.get($(script).attr('src'), null, function (data) { //1.a
           $(script).text (data); //1.b
           $(script).before('<!-- src="' + $(script).attr('src') + '" -->'); //1.d
           $(script).removeAttr("src"); //1.c
-        });
+        }, 'text');
       } //if (script.type == "text/javascript")
     });
 


### PR DESCRIPTION
As mentioned in #34, the portable HTML page is broken. Text fields and select lists do not populate due to silent failures while inlining scripts.

`EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' blob: filesystem: chrome-extension-resource:".`

This error can be exposed by adding a global AJAX handler like so to passhashplus.js:

`$.ajaxSetup({
			 error: function(xhr, status, error) {
				 console.error(error);
			 }
		 });`

The reason for the failure is that jQuery get() tries to execute scripts automatically after fetching them. This unfortunately is no longer allowed per the default extension Content Security Policy as detailed in https://developer.chrome.com/extensions/contentSecurityPolicy.

Since there is actually no need to execute the scripts, it is simple enough to have jQuery treat the scripts as plain text (no execution).

After this fix, both the local and downloaded portable HTML pages will work once again.